### PR TITLE
feat: create vc validate subject id

### DIFF
--- a/packages/identity-connector-iota/locales/en.json
+++ b/packages/identity-connector-iota/locales/en.json
@@ -29,7 +29,8 @@
 			"unrevokeVerifiableCredentialsFailed": "Unrevoking verifiable credentials failed",
 			"proofType": "The proof type must be DataIntegrityProof, it is currently {proofType}",
 			"integerNegative": "The value must be a positive integer, it is currently {value}",
-			"invalidDocumentIdFormat": "The document ID format is invalid, it is currently {documentId}"
+			"invalidDocumentIdFormat": "The document ID format is invalid, it is currently {documentId}",
+			"invalidSubjectId": "The subject id format is invalid it must be a Url or Urn, it is \"{subjectId}\""
 		}
 	}
 }

--- a/packages/identity-connector-iota/src/iotaIdentityConnector.ts
+++ b/packages/identity-connector-iota/src/iotaIdentityConnector.ts
@@ -45,7 +45,9 @@ import {
 	NotFoundError,
 	Converter,
 	ObjectHelper,
-	BaseError
+	BaseError,
+	Url,
+	Urn
 } from "@twin.org/core";
 import type { IJsonLdContextDefinitionRoot, IJsonLdNodeObject } from "@twin.org/data-json-ld";
 import { Iota } from "@twin.org/dlt-iota";
@@ -514,6 +516,15 @@ export class IotaIdentityConnector implements IIdentityConnector {
 			await keyIdMemStore.insertKeyId(methodDigest, keyId);
 
 			const storage = new Storage(jwkMemStore, keyIdMemStore);
+
+			const subjectId = subjectClone.id;
+			if (
+				Is.stringValue(subjectId) &&
+				!Url.tryParseExact(subjectId) &&
+				!Urn.tryParseExact(subjectId)
+			) {
+				throw new GeneralError(this.CLASS_NAME, "invalidSubjectId", { subjectId });
+			}
 
 			const unsignedVc = new Credential({
 				issuer: idParts.id,


### PR DESCRIPTION
When creating a VC the credential subject id must be in the form or a Urn or a Url, add validation so that the underlying rust doesn't throw an obtuse error